### PR TITLE
Revert prettier trailingComma option to es5

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ const config = (env, argv) => {
             return {
               code: await prettier.format(terserStep.code, {
                 filepath: Object.keys(file)[0],
-                trailingComma: 'all',
+                trailingComma: 'es5',
               }),
               map: terserStep.map,
               warnings: terserStep.warnings,


### PR DESCRIPTION
eb3f394 changed the `trailingComma` option for prettier to `all`.

This requires a higher version (ES2017) of JavaScript than the wiki currently supports, causing the calculators to fail to load when not in development mode.

This pull request should fix that, though I don't have the edit access required to confirm if this is the case.