### PR TITLE
Move strings to locales in used tools

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/tools/blockDistribution/*_block_count.json

--- a/src/common.less
+++ b/src/common.less
@@ -14,7 +14,6 @@
   ul.cdx-tabs__list {
     margin: 0;
   }
-
 }
 
 body.wgl-theme-dark {
@@ -29,5 +28,5 @@ body.wgl-theme-dark {
 }
 
 .mcw-calc-parameter {
-	display: none;
+  display: none;
 }

--- a/src/tools/armorColor/App.vue
+++ b/src/tools/armorColor/App.vue
@@ -128,7 +128,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
         >
           <label for="color-picker">{{ t('armorColor.color') }}</label>
           <input type="color" v-model="color" id="color-picker" />
-          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{ t('armorColor.calculate') }}</cdx-button>
+          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{
+            t('armorColor.calculate')
+          }}</cdx-button>
         </div>
         <div
           :style="{
@@ -163,10 +165,7 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
           ></span>
         </div>
         <div>
-          <span
-            class="explain"
-            :title="t('armorColor.dE.help')"
-          >
+          <span class="explain" :title="t('armorColor.dE.help')">
             {{ t('armorColor.dE') }}
           </span>
           = {{ sequence[1].toFixed(2) }}

--- a/src/tools/armorColor/App.vue
+++ b/src/tools/armorColor/App.vue
@@ -10,6 +10,10 @@ import {
 } from '@/utils/color'
 import { colorRgbMap as javaColorRgbMap } from '@/utils/color/java'
 import { colorRgbMap as bedrockColorRgbMap } from '@/utils/color/bedrock'
+import { useI18n } from '@/utils/i18n'
+import locales from './locales'
+
+const { t } = useI18n(__TOOL_NAME__, locales)
 
 const color = ref('#f9fffe')
 const edition = ref<'java' | 'bedrock'>('java')
@@ -97,11 +101,11 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
 </script>
 <template>
   <Field>
-    <template #heading>Calculate dye sequence for a leather (horse) armor color</template>
+    <template #heading>{{ t('armorColor.title') }}</template>
 
     <cdx-tabs v-model:active="edition">
-      <cdx-tab name="java" label="Java Edition" />
-      <cdx-tab name="bedrock" label="Bedrock Edition" />
+      <cdx-tab name="java" :label="t('armorColor.java')" />
+      <cdx-tab name="bedrock" :label="t('armorColor.bedrock')" />
     </cdx-tabs>
     <div
       :style="{
@@ -122,9 +126,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
             gap: '.5rem',
           }"
         >
-          <label for="color-picker">Color:</label>
+          <label for="color-picker">{{ t('armorColor.color') }}</label>
           <input type="color" v-model="color" id="color-picker" />
-          <cdx-button @click="updateSequence(colorStringToRgb(color))">Calculate</cdx-button>
+          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{ t('armorColor.calculate') }}</cdx-button>
         </div>
         <div
           :style="{
@@ -134,9 +138,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
             gap: '.5rem',
           }"
           class="explain"
-          title="You should dye the armor using all dyes at once."
+          :title="t('armorColor.sequence.help')"
         >
-          Sequence:
+          {{ t('armorColor.sequence') }}
           <div v-for="(item, index) in sequence[0]" :key="index">
             <img
               :src="generateDye(item)"
@@ -161,9 +165,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
         <div>
           <span
             class="explain"
-            title="Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes."
+            :title="t('armorColor.dE.help')"
           >
-            dE
+            {{ t('armorColor.dE') }}
           </span>
           = {{ sequence[1].toFixed(2) }}
         </div>

--- a/src/tools/armorColor/locales.ts
+++ b/src/tools/armorColor/locales.ts
@@ -1,0 +1,13 @@
+export default {
+    en: {
+        'armorColor.title': 'Calculate dye sequence for a leather (horse) armor color',
+        'armorColor.java': 'Java Edition',
+        'armorColor.bedrock': 'Bedrock Edition',
+        'armorColor.color': 'Color:',
+        'armorColor.calculate': 'Calculate',
+        'armorColor.sequence': 'Sequence:',
+        'armorColor.sequence.help': 'You should dye the armor using all dyes at once.',
+        'armorColor.dE': 'dE',
+        'armorColor.dE.help': 'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
+    },
+}

--- a/src/tools/armorColor/locales.ts
+++ b/src/tools/armorColor/locales.ts
@@ -1,13 +1,14 @@
 export default {
-    en: {
-        'armorColor.title': 'Calculate dye sequence for a leather (horse) armor color',
-        'armorColor.java': 'Java Edition',
-        'armorColor.bedrock': 'Bedrock Edition',
-        'armorColor.color': 'Color:',
-        'armorColor.calculate': 'Calculate',
-        'armorColor.sequence': 'Sequence:',
-        'armorColor.sequence.help': 'You should dye the armor using all dyes at once.',
-        'armorColor.dE': 'dE',
-        'armorColor.dE.help': 'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
-    },
+  en: {
+    'armorColor.title': 'Calculate dye sequence for a leather (horse) armor color',
+    'armorColor.java': 'Java Edition',
+    'armorColor.bedrock': 'Bedrock Edition',
+    'armorColor.color': 'Color:',
+    'armorColor.calculate': 'Calculate',
+    'armorColor.sequence': 'Sequence:',
+    'armorColor.sequence.help': 'You should dye the armor using all dyes at once.',
+    'armorColor.dE': 'dE',
+    'armorColor.dE.help':
+      'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
+  },
 }

--- a/src/tools/beaconColor/App.vue
+++ b/src/tools/beaconColor/App.vue
@@ -10,6 +10,10 @@ import {
 } from '@/utils/color'
 import { colorRgbMap as javaColorRgbMap } from '@/utils/color/java'
 import { colorRgbMap as bedrockColorRgbMap } from '@/utils/color/bedrock'
+import { useI18n } from '@/utils/i18n'
+import locales from './locales'
+
+const { t } = useI18n(__TOOL_NAME__, locales)
 
 const color = ref('#f9fffe')
 const edition = ref<'java' | 'bedrock'>('java')
@@ -66,11 +70,11 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
 </script>
 <template>
   <Field>
-    <template #heading>Calculate glass sequence for a beacon beam color</template>
+    <template #heading>{{ t('beaconColor.title') }}</template>
 
     <cdx-tabs v-model:active="edition">
-      <cdx-tab name="java" label="Java Edition" />
-      <cdx-tab name="bedrock" label="Bedrock Edition" />
+      <cdx-tab name="java" :label="t('beaconColor.java')" />
+      <cdx-tab name="bedrock" :label="t('beaconColor.bedrock')" />
     </cdx-tabs>
     <div
       :style="{
@@ -91,9 +95,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
             gap: '.5rem',
           }"
         >
-          <label for="color-picker">Color:</label>
+          <label for="color-picker">{{ t('beaconColor.color') }}</label>
           <input type="color" v-model="color" id="color-picker" />
-          <cdx-button @click="updateSequence(colorStringToRgb(color))">Calculate</cdx-button>
+          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{ t('beaconColor.calculate') }}</cdx-button>
         </div>
         <div
           :style="{
@@ -104,7 +108,7 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
             padding: '.3em 0px 0px 0px',
           }"
         >
-          Sequence:
+          {{ t('beaconColor.sequence') }}
           <div v-for="(item, index) in sequence[0]" :key="index">
             <img
               :src="generateGlass(item)"
@@ -129,9 +133,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
         <div>
           <span
             class="explain"
-            title="Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes."
+            :title="t('beaconColor.dE.help')"
           >
-            dE
+            {{ t('beaconColor.dE') }}
           </span>
           = {{ sequence[1].toFixed(2) }}
         </div>

--- a/src/tools/beaconColor/App.vue
+++ b/src/tools/beaconColor/App.vue
@@ -97,7 +97,9 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
         >
           <label for="color-picker">{{ t('beaconColor.color') }}</label>
           <input type="color" v-model="color" id="color-picker" />
-          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{ t('beaconColor.calculate') }}</cdx-button>
+          <cdx-button @click="updateSequence(colorStringToRgb(color))">{{
+            t('beaconColor.calculate')
+          }}</cdx-button>
         </div>
         <div
           :style="{
@@ -131,10 +133,7 @@ watch([sequence, canvasRef], ([sequence, canvasRef]) => {
           ></span>
         </div>
         <div>
-          <span
-            class="explain"
-            :title="t('beaconColor.dE.help')"
-          >
+          <span class="explain" :title="t('beaconColor.dE.help')">
             {{ t('beaconColor.dE') }}
           </span>
           = {{ sequence[1].toFixed(2) }}

--- a/src/tools/beaconColor/locales.ts
+++ b/src/tools/beaconColor/locales.ts
@@ -1,12 +1,13 @@
 export default {
-    en: {
-        'beaconColor.title': 'Calculate glass sequence for a beacon beam color',
-        'beaconColor.java': 'Java Edition',
-        'beaconColor.bedrock': 'Bedrock Edition',
-        'beaconColor.color': 'Color:',
-        'beaconColor.calculate': 'Calculate',
-        'beaconColor.sequence': 'Sequence:',
-        'beaconColor.dE': 'dE',
-        'beaconColor.dE.help': 'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
-    },
+  en: {
+    'beaconColor.title': 'Calculate glass sequence for a beacon beam color',
+    'beaconColor.java': 'Java Edition',
+    'beaconColor.bedrock': 'Bedrock Edition',
+    'beaconColor.color': 'Color:',
+    'beaconColor.calculate': 'Calculate',
+    'beaconColor.sequence': 'Sequence:',
+    'beaconColor.dE': 'dE',
+    'beaconColor.dE.help':
+      'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
+  },
 }

--- a/src/tools/beaconColor/locales.ts
+++ b/src/tools/beaconColor/locales.ts
@@ -1,0 +1,12 @@
+export default {
+    en: {
+        'beaconColor.title': 'Calculate glass sequence for a beacon beam color',
+        'beaconColor.java': 'Java Edition',
+        'beaconColor.bedrock': 'Bedrock Edition',
+        'beaconColor.color': 'Color:',
+        'beaconColor.calculate': 'Calculate',
+        'beaconColor.sequence': 'Sequence:',
+        'beaconColor.dE': 'dE',
+        'beaconColor.dE.help': 'Delta E is a measure of color proximity. Lower is better. Values ≤1.0 means the difference is not perceptible by human eyes.',
+    },
+}

--- a/src/tools/decimalColor/App.vue
+++ b/src/tools/decimalColor/App.vue
@@ -2,6 +2,10 @@
 import Field from '@/components/Field.vue'
 import { ref, computed } from 'vue'
 import { colorStringToRgb } from '@/utils/color'
+import { useI18n } from '@/utils/i18n'
+import locales from './locales'
+
+const { t } = useI18n(__TOOL_NAME__, locales)
 
 const color = ref('#f9fffe')
 const result = computed({
@@ -21,7 +25,7 @@ const result = computed({
 </script>
 <template>
   <Field>
-    <template #heading>Calculate decimal representation of color</template>
+    <template #heading>{{ t('decimalColor.title') }}</template>
 
     <div
       :style="{
@@ -42,7 +46,7 @@ const result = computed({
             gap: '.5rem',
           }"
         >
-          <label for="decimalColor-color-picker">Color:</label>
+          <label for="decimalColor-color-picker">{{ t('decimalColor.color') }}</label>
           <input type="color" v-model="color" id="decimalColor-color-picker" />
         </div>
         <div
@@ -53,7 +57,7 @@ const result = computed({
             gap: '.5rem',
           }"
         >
-          <label for="decimalColor-color-picker-output">Decimal:</label>
+          <label for="decimalColor-color-picker-output">{{ t('decimalColor.decimal') }}</label>
           <input type="text" v-model="result" id="decimalColor-color-picker-output" />
         </div>
       </div>

--- a/src/tools/decimalColor/locales.ts
+++ b/src/tools/decimalColor/locales.ts
@@ -1,0 +1,7 @@
+export default {
+    en: {
+        'decimalColor.title': 'Calculate decimal representation of color',
+        'decimalColor.color': 'Color:',
+        'decimalColor.decimal': 'Decimal:',
+    },
+}

--- a/src/tools/decimalColor/locales.ts
+++ b/src/tools/decimalColor/locales.ts
@@ -1,7 +1,7 @@
 export default {
-    en: {
-        'decimalColor.title': 'Calculate decimal representation of color',
-        'decimalColor.color': 'Color:',
-        'decimalColor.decimal': 'Decimal:',
-    },
+  en: {
+    'decimalColor.title': 'Calculate decimal representation of color',
+    'decimalColor.color': 'Color:',
+    'decimalColor.decimal': 'Decimal:',
+  },
 }

--- a/src/tools/seedHashcode/App.vue
+++ b/src/tools/seedHashcode/App.vue
@@ -23,8 +23,6 @@ function hashCode(s: string) {
     <template #heading>{{ t('seedHashcode.title') }}</template>
     <CdxTextInput v-model="seed" />
     {{ t('seedHashcode.actual') }} <code v-if="seed !== ''">{{ hashCode(seed) }}</code
-    ><template v-else
-      >{{ t('seedHashcode.emptyString') }}</template
-    >
+    ><template v-else>{{ t('seedHashcode.emptyString') }}</template>
   </Field>
 </template>

--- a/src/tools/seedHashcode/App.vue
+++ b/src/tools/seedHashcode/App.vue
@@ -2,7 +2,13 @@
 import { ref } from 'vue'
 import { CdxTextInput } from '@wikimedia/codex'
 import Field from '@/components/Field.vue'
+import { useI18n } from '@/utils/i18n'
+import locales from './locales'
+
+const { t } = useI18n(__TOOL_NAME__, locales)
+
 const seed = ref('Minecraft Wiki')
+
 // Java String.hashCode() implementation
 function hashCode(s: string) {
   let h = 0
@@ -14,12 +20,11 @@ function hashCode(s: string) {
 </script>
 <template>
   <Field>
-    <template #heading>Convert a string to actual seed</template>
+    <template #heading>{{ t('seedHashcode.title') }}</template>
     <CdxTextInput v-model="seed" />
-    Actual seed: <code v-if="seed !== ''">{{ hashCode(seed) }}</code
+    {{ t('seedHashcode.actual') }} <code v-if="seed !== ''">{{ hashCode(seed) }}</code
     ><template v-else
-      >This should be 0, but it is an empty string, so Minecraft actually generates a random
-      number.</template
+      >{{ t('seedHashcode.emptyString') }}</template
     >
   </Field>
 </template>

--- a/src/tools/seedHashcode/locales.ts
+++ b/src/tools/seedHashcode/locales.ts
@@ -1,0 +1,7 @@
+export default {
+    en: {
+        'seedHashcode.title': 'Convert a string to actual seed',
+        'seedHashcode.actual': 'Actual seed:',
+        'seedHashcode.emptyString': 'This should be 0, but it is an empty string, so Minecraft actually generates a random number.',
+    },
+}

--- a/src/tools/seedHashcode/locales.ts
+++ b/src/tools/seedHashcode/locales.ts
@@ -1,7 +1,8 @@
 export default {
-    en: {
-        'seedHashcode.title': 'Convert a string to actual seed',
-        'seedHashcode.actual': 'Actual seed:',
-        'seedHashcode.emptyString': 'This should be 0, but it is an empty string, so Minecraft actually generates a random number.',
-    },
+  en: {
+    'seedHashcode.title': 'Convert a string to actual seed',
+    'seedHashcode.actual': 'Actual seed:',
+    'seedHashcode.emptyString':
+      'This should be 0, but it is an empty string, so Minecraft actually generates a random number.',
+  },
 }


### PR DESCRIPTION
This moves strings to locales of 4 tools used on the wiki (`armorColor`, `beaconColor`, `decimalColor` & `seedHashcode`).
One thing I couldn't figure out is how to make Minecraft items translatable in a simple way (glass panes and dyes). Any idea?