### PR TITLE
Fix blockDistribution display count in logarithm scale

### DIFF
--- a/src/tools/blockDistribution/App.vue
+++ b/src/tools/blockDistribution/App.vue
@@ -239,13 +239,17 @@ function plot(
     const [xm, ym] = d3.pointer(event)
     const i = d3.leastIndex(points, ([x, y]) => Math.hypot(x - xm, y - ym))!
     const [x1, y1, k] = points[i]
+    const pos = x.invert(x1)
     dot.attr('transform', `translate(${x1},${y1})`)
     const formatter = d3.format('d')
     dot.select('text').html(
       `<tspan x="0" dy="1.2em">${t('blockDistribution.xInTenThousand', {
-        num: formatter(y.invert(y1)),
+        num: formatter(
+          blockMapFiltered.find((b) => b.block === k && Math.abs(b.pos - pos) < 1e-7)?.count ??
+          y.invert(y1),
+        ),
       })}</tspan>
-        <tspan x="0" dy="1.2em">Y=${formatter(x.invert(x1))}</tspan>
+        <tspan x="0" dy="1.2em">Y=${formatter(pos)}</tspan>
         <tspan x="0" dy="1.2em">${k}</tspan>`,
     )
     svg.property('value', points[i][2]).dispatch('input', { bubbles: true } as any)


### PR DESCRIPTION
Original issue link: [zh:Talk:凝灰岩](https://zh.minecraft.wiki/w/Talk:%E5%87%9D%E7%81%B0%E5%B2%A9#%E5%87%9D%E7%81%B0%E5%B2%A9%E6%AF%8F%E5%B1%82%E7%9A%84%E5%88%86%E5%B8%83%E6%95%B0%E5%80%BC%E6%98%BE%E7%A4%BA%E4%BC%BC%E4%B9%8E%E6%9C%89%E9%97%AE%E9%A2%98).