### PR TITLE
Add missing translation for formattingCodeEditor

### DIFF
--- a/src/tools/formattingCodeEditor/locale/de.json
+++ b/src/tools/formattingCodeEditor/locale/de.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Werkstoff Diamant",
   "formattingCodeEditor.color.material_lapis": "Werkstoff Lapislazuli",
   "formattingCodeEditor.color.material_amethyst": "Werkstoff Amethyst",
+  "formattingCodeEditor.color.material_resin": "Werkstoff Harz",
   "formattingCodeEditor.color.none": "Keine Farbe",
   "formattingCodeEditor.format.bold": "Fett",
   "formattingCodeEditor.format.italic": "Kursiv",

--- a/src/tools/formattingCodeEditor/locale/en.json
+++ b/src/tools/formattingCodeEditor/locale/en.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Material Diamond",
   "formattingCodeEditor.color.material_lapis": "Material Lapis",
   "formattingCodeEditor.color.material_amethyst": "Material Amethyst",
+  "formattingCodeEditor.color.material_resin": "Material Resin",
   "formattingCodeEditor.color.none": "No color",
   "formattingCodeEditor.format.bold": "Bold",
   "formattingCodeEditor.format.italic": "Italic",

--- a/src/tools/formattingCodeEditor/locale/es.json
+++ b/src/tools/formattingCodeEditor/locale/es.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Incrustaciones de diamante",
   "formattingCodeEditor.color.material_lapis": "Incrustaciones de lapislázuli",
   "formattingCodeEditor.color.material_amethyst": "Incrustaciones de amatista",
+  "formattingCodeEditor.color.material_resin": "Incrustaciones de resina",
   "formattingCodeEditor.color.none": "Sin color",
   "formattingCodeEditor.format.bold": "Negrita",
   "formattingCodeEditor.format.italic": "Cursiva",

--- a/src/tools/formattingCodeEditor/locale/fr.json
+++ b/src/tools/formattingCodeEditor/locale/fr.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Matériau diamant",
   "formattingCodeEditor.color.material_lapis": "Matériau lapis",
   "formattingCodeEditor.color.material_amethyst": "Matériau améthyste",
+  "formattingCodeEditor.color.material_resin": "Matériau résine",
   "formattingCodeEditor.color.none": "Pas de couleur",
   "formattingCodeEditor.format.bold": "Gras",
   "formattingCodeEditor.format.italic": "Italique",

--- a/src/tools/formattingCodeEditor/locale/ja.json
+++ b/src/tools/formattingCodeEditor/locale/ja.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "ダイヤモンド素材色",
   "formattingCodeEditor.color.material_lapis": "ラピスラズリ素材色",
   "formattingCodeEditor.color.material_amethyst": "アメジスト素材色",
+  "formattingCodeEditor.color.material_resin": "樹脂素材色",
   "formattingCodeEditor.color.none": "色指定なし",
   "formattingCodeEditor.format.bold": "太字",
   "formattingCodeEditor.format.italic": "斜体",

--- a/src/tools/formattingCodeEditor/locale/ko.json
+++ b/src/tools/formattingCodeEditor/locale/ko.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "다이아몬드 소재 색",
   "formattingCodeEditor.color.material_lapis": "청금석 소재 색",
   "formattingCodeEditor.color.material_amethyst": "자수정 소재 색",
+  "formattingCodeEditor.color.material_resin": "수지 소재 색",
   "formattingCodeEditor.color.none": "색 없음",
   "formattingCodeEditor.format.bold": "굵게",
   "formattingCodeEditor.format.italic": "기울이기",

--- a/src/tools/formattingCodeEditor/locale/pt.json
+++ b/src/tools/formattingCodeEditor/locale/pt.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Material de Diamante",
   "formattingCodeEditor.color.material_lapis": "Material de Lápis-Lazúli",
   "formattingCodeEditor.color.material_amethyst": "Material de Ametista",
+  "formattingCodeEditor.color.material_resin": "Material de Resina",
   "formattingCodeEditor.color.none": "Sem cor",
   "formattingCodeEditor.format.bold": "Negrito",
   "formattingCodeEditor.format.italic": "Itálico",

--- a/src/tools/formattingCodeEditor/locale/uk.json
+++ b/src/tools/formattingCodeEditor/locale/uk.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "Матеріал «Діамант»",
   "formattingCodeEditor.color.material_lapis": "Матеріал «Лазурит»",
   "formattingCodeEditor.color.material_amethyst": "Матеріал «Аметист»",
+  "formattingCodeEditor.color.material_resin": "Матеріал «Смоли»",
   "formattingCodeEditor.color.none": "Безбарвний",
   "formattingCodeEditor.format.bold": "Жирний",
   "formattingCodeEditor.format.italic": "Курсив",

--- a/src/tools/formattingCodeEditor/locale/zh-cn.json
+++ b/src/tools/formattingCodeEditor/locale/zh-cn.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "钻石色",
   "formattingCodeEditor.color.material_lapis": "青金石色",
   "formattingCodeEditor.color.material_amethyst": "紫水晶色",
+  "formattingCodeEditor.color.material_resin": "树脂色",
   "formattingCodeEditor.color.none": "不指定颜色",
   "formattingCodeEditor.format.bold": "粗体",
   "formattingCodeEditor.format.italic": "斜体",

--- a/src/tools/formattingCodeEditor/locale/zh-hk.json
+++ b/src/tools/formattingCodeEditor/locale/zh-hk.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "鑽石質",
   "formattingCodeEditor.color.material_lapis": "青金石質",
   "formattingCodeEditor.color.material_amethyst": "紫水晶質",
+  "formattingCodeEditor.color.material_resin": "樹脂質",
   "formattingCodeEditor.color.none": "不指定顏色",
   "formattingCodeEditor.format.bold": "粗體",
   "formattingCodeEditor.format.italic": "斜體",

--- a/src/tools/formattingCodeEditor/locale/zh-tw.json
+++ b/src/tools/formattingCodeEditor/locale/zh-tw.json
@@ -31,6 +31,7 @@
   "formattingCodeEditor.color.material_diamond": "鑽石材質",
   "formattingCodeEditor.color.material_lapis": "青金石材質",
   "formattingCodeEditor.color.material_amethyst": "紫水晶材質",
+  "formattingCodeEditor.color.material_resin": "樹脂材質",
   "formattingCodeEditor.color.none": "不指定顏色",
   "formattingCodeEditor.format.bold": "粗體",
   "formattingCodeEditor.format.italic": "斜體",


### PR DESCRIPTION
Filled in the missing key `formattingCodeEditor.color.material_resin` based on the Minecraft project on Crowdin.

Additionally, although I attempted to infer patterns from existing translations, I was still unable to determine appropriate translations for Russian and Thai.