### PR TITLE
Replace MinecraftWiki default username with MinwiMCW in Player UUID calculator

### DIFF
--- a/src/tools/playerUuid/main.ts
+++ b/src/tools/playerUuid/main.ts
@@ -13,7 +13,7 @@ const i18n = createMcwI18n([import.meta.glob('./locale/*.json', { eager: true })
 ;(async () => {
   const parsed = z
     .object({
-      player: z.string().default('MinecraftWiki'),
+      player: z.string().default('MinwiMCW'),
     })
     .safeParse(await getParams())
 


### PR DESCRIPTION
Requested by muzikbike. It appears that we don't know who owns the MinecraftWiki username on Java, but MinwiMCW is owned by [User:RustCurve164933](https://minecraft.wiki/w/User:RustCurve164933). It has the added advantage of having the Minwi skin, as well!
<img width="1302" height="365" alt="image" src="https://github.com/user-attachments/assets/6d171a1f-4da4-411a-8cfe-d7a7155ec391" />