### PR TITLE
Add Random Tick calculator and Table

### DIFF
--- a/src/tools/randomTick/App.vue
+++ b/src/tools/randomTick/App.vue
@@ -1,0 +1,310 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { CdxTextInput } from '@wikimedia/codex'
+import CalcField from '@/components/CalcField.vue'
+
+const { t } = useI18n()
+
+// ── Inputs ────────────────────────────────────────────────────────────────────
+
+const randomTickSpeed = ref(3)
+const stages = ref(7)
+const growthChancePct = ref(100)   // user enters as percentage, e.g. 10 for 10%
+const avgDropsPerHarvest = ref(1)
+const stackSize = ref(64)
+
+// ── Core probability ──────────────────────────────────────────────────────────
+
+// Probability that a given block advances one stage on a single game tick.
+// Each subchunk tick fires `randomTickSpeed` attempts across 4096 blocks,
+// so the chance of being selected at least once ≈ randomTickSpeed / 4096
+// (exact: 1 - ((4095/4096)^randomTickSpeed), but the approximation is
+// standard and matches the wiki's figures).
+// Then the block's own growth chance (e.g. 10% for nether wart) applies on top.
+const p = computed(() => {
+  const rts = randomTickSpeed.value
+  const gc = growthChancePct.value / 100
+  if (rts <= 0 || gc <= 0) return 0
+  return (rts / 4096) * gc
+})
+
+// ── Average calculations ───────────────────────────────────────────────────────
+
+// Each stage is geometrically distributed with success probability p.
+// Mean of a geometric RV = 1/p (in ticks).
+const avgTicksPerStage = computed(() => (p.value > 0 ? 1 / p.value : Infinity))
+
+// Total growth = sum of `stages` geometric RVs → mean = stages / p
+const avgTicksTotal = computed(() => (p.value > 0 ? stages.value / p.value : Infinity))
+
+const avgSecondsPerStage = computed(() => avgTicksPerStage.value / 20)
+const avgSecondsTotal = computed(() => avgTicksTotal.value / 20)
+
+// ── Median calculation (numerical approximation) ──────────────────────────────
+//
+// Total growth time follows a Negative Binomial distribution NB(stages, p).
+// There is no closed-form median, so we walk the CDF until it first reaches
+// or exceeds 0.5.  This is an approximation because:
+//   1. We use the exact discrete CDF rather than a continuous approximation.
+//   2. For extremely small p (huge tick counts), we cap at a practical limit.
+//
+// CDF of NB(r, p) at k successes-worth-of-trials:
+//   P(T ≤ n) = I_p(r, n - r + 1)   [regularised incomplete beta]
+// We compute it iteratively via the PMF recurrence instead, which is stable
+// and avoids special functions.
+
+const medianTicksTotal = computed((): number | null => {
+  const r = stages.value
+  const prob = p.value
+  if (prob <= 0 || r <= 0) return null
+
+  // PMF of NB(r, prob) at n total trials:
+  //   P(T = n) = C(n-1, r-1) * prob^r * (1-prob)^(n-r)
+  // We use the log-PMF recurrence to avoid overflow:
+  //   logPMF(n+1) = logPMF(n) + log(n) - log(n - r) + log(1 - prob)
+  const logProb = Math.log(prob)
+  const logQ = Math.log(1 - prob)
+
+  // Start at n = r (minimum possible, all successes)
+  // logPMF(r) = r * log(prob)   [C(r-1,r-1)=1, (1-p)^0=1]
+  let logPmf = r * logProb
+  let cdf = Math.exp(logPmf)
+
+  if (cdf >= 0.5) return r   // degenerate case (p very close to 1)
+
+  const MAX_ITER = 10_000_000
+  for (let n = r + 1; n <= r + MAX_ITER; n++) {
+    // Recurrence: PMF(n) = PMF(n-1) * (n-1)/(n-r) * (1-p)
+    logPmf += Math.log(n - 1) - Math.log(n - r) + logQ
+    cdf += Math.exp(logPmf)
+    if (cdf >= 0.5) return n
+  }
+
+  return null   // exceeded practical limit
+})
+
+const medianSecondsTotal = computed(() =>
+  medianTicksTotal.value !== null ? medianTicksTotal.value / 20 : null
+)
+
+// ── Stack calculator ───────────────────────────────────────────────────────────
+
+const harvestsForStack = computed(() => {
+  if (avgDropsPerHarvest.value <= 0) return Infinity
+  return Math.ceil(stackSize.value / avgDropsPerHarvest.value)
+})
+
+const avgTicksForStack = computed(() =>
+  harvestsForStack.value === Infinity ? Infinity : harvestsForStack.value * avgTicksTotal.value
+)
+
+const avgSecondsForStack = computed(() => avgTicksForStack.value / 20)
+
+// ── Formatting helpers ─────────────────────────────────────────────────────────
+
+function fmtTicks(t: number): string {
+  if (!isFinite(t)) return '∞'
+  return t.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
+function fmtSeconds(s: number): string {
+  if (!isFinite(s)) return '∞'
+  if (s < 60) return `${s.toFixed(2)}s`
+  const m = Math.floor(s / 60)
+  const sec = s % 60
+  if (m < 60) return `${m}m ${sec.toFixed(1)}s`
+  const h = Math.floor(m / 60)
+  const min = m % 60
+  return `${h}h ${min}m ${(s % 60).toFixed(0)}s`
+}
+</script>
+
+<template>
+  <CalcField>
+    <template #heading>
+      {{ t('randomTick.growth.title') }}
+    </template>
+
+    <!-- ── Inputs ── -->
+    <div class="flex flex-wrap gap-4 mb-6">
+
+      <div class="input-item">
+        <div class="input-input">
+          <CdxTextInput
+            v-model="randomTickSpeed"
+            class="text-center min-w-16"
+            input-type="number"
+            min="1"
+          />
+          <span class="explain" :title="t('randomTick.growth.rts.explain')">
+            {{ t('randomTick.growth.rts') }}
+          </span>
+        </div>
+      </div>
+
+      <div class="input-item">
+        <div class="input-input">
+          <CdxTextInput
+            v-model="stages"
+            class="text-center min-w-16"
+            input-type="number"
+            min="1"
+          />
+          <span>{{ t('randomTick.growth.stages') }}</span>
+        </div>
+      </div>
+
+      <div class="input-item">
+        <div class="input-input">
+          <CdxTextInput
+            v-model="growthChancePct"
+            class="text-center min-w-16"
+            input-type="number"
+            min="0.01"
+            max="100"
+          />
+          <span class="explain" :title="t('randomTick.growth.chance.explain')">
+            {{ t('randomTick.growth.chance') }}
+          </span>
+        </div>
+      </div>
+
+      <div class="input-item">
+        <div class="input-input">
+          <CdxTextInput
+            v-model="avgDropsPerHarvest"
+            class="text-center min-w-16"
+            input-type="number"
+            min="0.01"
+          />
+          <span class="explain" :title="t('randomTick.growth.drops.explain')">
+            {{ t('randomTick.growth.drops') }}
+          </span>
+        </div>
+      </div>
+
+      <div class="input-item">
+        <div class="input-input">
+          <CdxTextInput
+            v-model="stackSize"
+            class="text-center min-w-16"
+            input-type="number"
+            min="1"
+          />
+          <span>{{ t('randomTick.growth.stackSize') }}</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- ── Note ── -->
+    <p class="rt-note mb-4">
+      {{ t('randomTick.growth.optimalNote') }}
+    </p>
+
+    <!-- ── Results table ── -->
+    <table class="rt-results">
+      <thead>
+        <tr>
+          <th>{{ t('randomTick.growth.metric') }}</th>
+          <th>{{ t('randomTick.growth.realTime') }}</th>
+          <th>{{ t('randomTick.growth.ticks') }}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>{{ t('randomTick.growth.avgPerStage') }}</td>
+          <td>{{ fmtSeconds(avgSecondsPerStage) }}</td>
+          <td>{{ fmtTicks(avgTicksPerStage) }}</td>
+        </tr>
+        <tr>
+          <td>{{ t('randomTick.growth.avgTotal') }}</td>
+          <td>{{ fmtSeconds(avgSecondsTotal) }}</td>
+          <td>{{ fmtTicks(avgTicksTotal) }}</td>
+        </tr>
+        <tr>
+          <td>
+            {{ t('randomTick.growth.medianTotal') }}
+            <span class="rt-approx" :title="t('randomTick.growth.medianExplain')">~</span>
+          </td>
+          <td>{{ medianSecondsTotal !== null ? fmtSeconds(medianSecondsTotal) : '—' }}</td>
+          <td>{{ medianTicksTotal !== null ? fmtTicks(medianTicksTotal) : '—' }}</td>
+        </tr>
+        <tr class="rt-divider">
+          <td colspan="3"></td>
+        </tr>
+        <tr>
+          <td>{{ t('randomTick.growth.harvestsForStack', { n: stackSize }) }}</td>
+          <td colspan="2">{{ harvestsForStack === Infinity ? '∞' : harvestsForStack }}</td>
+        </tr>
+        <tr>
+          <td>{{ t('randomTick.growth.avgTimeForStack', { n: stackSize }) }}</td>
+          <td>{{ fmtSeconds(avgSecondsForStack) }}</td>
+          <td>{{ fmtTicks(avgTicksForStack) }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </CalcField>
+</template>
+
+<style lang="less">
+.rt-note {
+  font-size: 0.875rem;
+  color: var(--color-subtle, #666);
+  font-style: italic;
+}
+
+.rt-approx {
+  display: inline-block;
+  margin-left: 4px;
+  font-weight: bold;
+  color: var(--color-subtle, #888);
+  cursor: help;
+  font-style: normal;
+}
+
+.rt-results {
+  border-collapse: collapse;
+  width: 100%;
+  font-family: monospace;
+
+  th, td {
+    padding: 4px 12px;
+    text-align: left;
+    border: 1px solid var(--border-color-base, #a2a9b1);
+  }
+
+  th {
+    background: var(--background-color-neutral, #eaecf0);
+    font-weight: bold;
+  }
+
+  tr:nth-child(even) td {
+    background: var(--background-color-neutral-subtle, #f8f9fa);
+  }
+
+  .rt-divider td {
+    padding: 2px;
+    background: var(--border-color-base, #a2a9b1);
+    border: none;
+  }
+}
+
+/* Reuse input layout from tick calc */
+.input-item {
+  display: flex;
+  flex-direction: row;
+  gap: 0.25rem;
+}
+
+.input-input {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.cdx-text-input {
+  font-family: monospace;
+  width: 84px;
+}
+</style>

--- a/src/tools/randomTick/index.html
+++ b/src/tools/randomTick/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>randomTick</title>
+    <base target="_parent" />
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script type="module" src="/tools/randomTick/main.ts"></script>
+  </body>
+</html>

--- a/src/tools/randomTick/locale/en.json
+++ b/src/tools/randomTick/locale/en.json
@@ -1,0 +1,21 @@
+{
+  "randomTick.growth.title": "Random Tick Growth Calculator",
+  "randomTick.growth.rts": "randomTickSpeed",
+  "randomTick.growth.rts.explain": "The /gamerule randomTickSpeed value (default: 3)",
+  "randomTick.growth.stages": "Growth stages",
+  "randomTick.growth.chance": "Growth chance %",
+  "randomTick.growth.chance.explain": "Probability that a ticked block actually advances one stage",
+  "randomTick.growth.drops": "Avg. drops/harvest",
+  "randomTick.growth.drops.explain": "Average number of items dropped per harvest",
+  "randomTick.growth.stackSize": "Stack size",
+  "randomTick.growth.metric": "Metric",
+  "randomTick.growth.ticks": "Game ticks",
+  "randomTick.growth.realTime": "Real time (20 TPS)",
+  "randomTick.growth.avgPerStage": "Average time per stage",
+  "randomTick.growth.avgTotal": "Average total growth time",
+  "randomTick.growth.medianTotal": "Median total growth time",
+  "randomTick.growth.medianExplain": "Approximated numerically from the negative binomial CDF; no closed-form median exists for this distribution.",
+  "randomTick.growth.harvestsForStack": "Harvests needed for stack of {n}",
+  "randomTick.growth.avgTimeForStack": "Avg. time for stack of {n}",
+  "randomTick.growth.optimalNote": "Growth chance assumes optimal conditions (hydrated farmland, alternating rows, etc.) unless otherwise specified."
+}

--- a/src/tools/randomTick/main.ts
+++ b/src/tools/randomTick/main.ts
@@ -1,0 +1,10 @@
+import * as vue from 'vue'
+import { createMcwI18n } from '@/utils/i18n'
+import plugin from '@/utils/plugin'
+import App from './App.vue'
+import '@/init'
+
+const targetEl = document.querySelector('#app')!
+
+const i18n = createMcwI18n([import.meta.glob('./locale/*.json', { eager: true })])
+vue.createApp(App).use(i18n).use(plugin).mount(targetEl)

--- a/src/tools/randomTickTable/App.vue
+++ b/src/tools/randomTickTable/App.vue
@@ -13,7 +13,7 @@ interface Entry {
   name: string            // Display name, also used as link target if link is absent
   link?: string           // Optional wiki page name; falls back to name if omitted
   stages?: number | null  // omit or null = single-action block (e.g. lit redstone ore)
-  growthChance: number    // 0–1 probability of advancing one stage when ticked
+  growthChance?: number   // 0–1 probability of advancing one stage when ticked; defaults to 1.0
   avgDrops?: number       // Average items dropped per harvest; omit for non-harvestable blocks
   stackSize?: number      // Stack size for that item; defaults to 64
   notes?: string
@@ -125,12 +125,13 @@ const rows = computed((): RowData[] => {
 
   return props.entries.map((entry): RowData => {
     const effectiveStages = entry.stages ?? 1
+    const effectiveGrowthChance = entry.growthChance ?? 1
     const isExact = effectiveStages === 1
-    const perAction = avgTicksPerAction(entry.growthChance, rts)
-    const total = avgTicksTotal(effectiveStages, entry.growthChance, rts)
+    const perAction = avgTicksPerAction(effectiveGrowthChance, rts)
+    const total = avgTicksTotal(effectiveStages, effectiveGrowthChance, rts)
     const median = isExact
-      ? exactGeometricMedian(entry.growthChance, rts)
-      : medianTicksTotal(effectiveStages, entry.growthChance, rts)
+      ? exactGeometricMedian(effectiveGrowthChance, rts)
+      : medianTicksTotal(effectiveStages, effectiveGrowthChance, rts)
 
     const avgTicksForTarget = entry.avgDrops !== undefined
       ? (Math.ceil(target / (entry.avgDrops * crops)) * total)

--- a/src/tools/randomTickTable/App.vue
+++ b/src/tools/randomTickTable/App.vue
@@ -1,0 +1,357 @@
+<script setup lang="ts">
+import { CdxCheckbox, CdxTextInput } from '@wikimedia/codex'
+import { computed, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { parseWikitext } from '@/utils/i18n'
+import CalcField from '@/components/CalcField.vue'
+
+const { t } = useI18n()
+
+// ── Types ──────────────────────────────────────────────────────────────────────
+
+interface Entry {
+  name: string            // Display name, also used as link target if link is absent
+  link?: string           // Optional wiki page name; falls back to name if omitted
+  stages?: number | null  // omit or null = single-action block (e.g. lit redstone ore)
+  growthChance: number    // 0–1 probability of advancing one stage when ticked
+  avgDrops?: number       // Average items dropped per harvest; omit for non-harvestable blocks
+  stackSize?: number      // Stack size for that item; defaults to 64
+  notes?: string
+}
+
+// ── Props ──────────────────────────────────────────────────────────────────────
+
+const props = defineProps<{
+  entries: Entry[]
+}>()
+
+// ── Inputs ─────────────────────────────────────────────────────────────────────
+
+const randomTickSpeed = ref(3)
+const cropCount = ref(1)
+const useCropCount = ref(false)
+const targetItems = ref(64)
+
+// ── Math ───────────────────────────────────────────────────────────────────────
+
+const SUBCHUNK = 4096
+
+function tickProb(growthChance: number, rts: number): number {
+  return (rts / SUBCHUNK) * growthChance
+}
+
+function avgTicksPerAction(growthChance: number, rts: number): number {
+  return 1 / tickProb(growthChance, rts)
+}
+
+function avgTicksTotal(stages: number, growthChance: number, rts: number): number {
+  return stages / tickProb(growthChance, rts)
+}
+
+// Exact median for a single geometric RV (stages = 1):
+// ceil(log(0.5) / log(1 - p))
+function exactGeometricMedian(growthChance: number, rts: number): number {
+  const prob = tickProb(growthChance, rts)
+  return Math.ceil(Math.log(0.5) / Math.log(1 - prob))
+}
+
+// Numerical approximation of the median of NB(stages, p).
+// Walks the CDF via the log-PMF recurrence until it first reaches ≥ 0.5.
+function medianTicksTotal(stages: number, growthChance: number, rts: number): number | null {
+  const prob = tickProb(growthChance, rts)
+  if (prob <= 0 || stages <= 0) return null
+
+  const logProb = Math.log(prob)
+  const logQ = Math.log(1 - prob)
+
+  let logPmf = stages * logProb
+  let cdf = Math.exp(logPmf)
+
+  if (cdf >= 0.5) return stages
+
+  const MAX_ITER = 10_000_000
+  for (let n = stages + 1; n <= stages + MAX_ITER; n++) {
+    logPmf += Math.log(n - 1) - Math.log(n - stages) + logQ
+    cdf += Math.exp(logPmf)
+    if (cdf >= 0.5) return n
+  }
+  return null
+}
+
+// ── Formatting ─────────────────────────────────────────────────────────────────
+
+function fmtTime(ticks: number): string {
+  const totalSeconds = ticks / 20
+  if (totalSeconds < 60) return `${totalSeconds.toFixed(1)}${t('randomTickTable.unit.s')}`
+  const totalMinutes = Math.floor(totalSeconds / 60)
+  const secs = Math.round(totalSeconds % 60)
+  if (totalMinutes < 60) return secs > 0
+    ? `${totalMinutes}${t('randomTickTable.unit.m')} ${secs}${t('randomTickTable.unit.s')}`
+    : `${totalMinutes}${t('randomTickTable.unit.m')}`
+  const hours = Math.floor(totalMinutes / 60)
+  const mins = totalMinutes % 60
+  return mins > 0
+    ? `${hours}${t('randomTickTable.unit.h')} ${mins}${t('randomTickTable.unit.m')}`
+    : `${hours}${t('randomTickTable.unit.h')}`
+}
+
+function fmtTicks(n: number): string {
+  return `${n.toLocaleString(undefined, { maximumFractionDigits: 0 })} ${t('randomTickTable.unit.gt')}`
+}
+
+function renderLink(entry: Entry): string {
+  const target = entry.link ?? entry.name
+  return parseWikitext(`[[${target}|${entry.name}]]`)
+}
+
+// ── Per-row computed data ──────────────────────────────────────────────────────
+
+interface RowData {
+  entry: Entry
+  renderedLink: string
+  stagesIsNull: boolean
+  avgPerAction: number
+  avgTotal: number
+  medianTotal: number | null
+  medianExact: boolean
+  avgDrops: number | undefined
+  avgTicksForTarget: number | null
+}
+
+const rows = computed((): RowData[] => {
+  const rts = randomTickSpeed.value
+  const crops = useCropCount.value ? Math.max(1, cropCount.value) : 1
+  const target = Math.max(1, targetItems.value)
+
+  return props.entries.map((entry): RowData => {
+    const effectiveStages = entry.stages ?? 1
+    const isExact = effectiveStages === 1
+    const perAction = avgTicksPerAction(entry.growthChance, rts)
+    const total = avgTicksTotal(effectiveStages, entry.growthChance, rts)
+    const median = isExact
+      ? exactGeometricMedian(entry.growthChance, rts)
+      : medianTicksTotal(effectiveStages, entry.growthChance, rts)
+
+    const avgTicksForTarget = entry.avgDrops !== undefined
+      ? (Math.ceil(target / (entry.avgDrops * crops)) * total)
+      : null
+
+    return {
+      entry,
+      renderedLink: renderLink(entry),
+      stagesIsNull: entry.stages == null,
+      avgPerAction: perAction,
+      avgTotal: total,
+      medianTotal: median,
+      medianExact: isExact,
+      avgDrops: entry.avgDrops,
+      avgTicksForTarget,
+    }
+  })
+})
+</script>
+
+<template>
+  <CalcField>
+    <template #heading>{{ t('randomTickTable.title') }}</template>
+
+    <!-- ── Controls ── -->
+    <div class="flex flex-wrap gap-4 mb-4 items-end">
+
+      <div class="input-input">
+        <CdxTextInput
+          v-model="randomTickSpeed"
+          class="text-center min-w-16"
+          input-type="number"
+          min="1"
+        />
+        <span class="explain" :title="t('randomTickTable.rts.explain')">
+          {{ t('randomTickTable.rts') }}
+        </span>
+      </div>
+
+      <div class="input-input">
+        <CdxTextInput
+          v-model="targetItems"
+          class="text-center min-w-16"
+          input-type="number"
+          min="1"
+        />
+        <span>{{ t('randomTickTable.targetItems') }}</span>
+      </div>
+
+      <div class="flex flex-col gap-1">
+        <CdxCheckbox v-model="useCropCount">
+          {{ t('randomTickTable.useCropCount') }}
+        </CdxCheckbox>
+        <div class="input-input" :class="{ 'rt-disabled': !useCropCount }">
+          <CdxTextInput
+            v-model="cropCount"
+            class="text-center min-w-16"
+            input-type="number"
+            min="1"
+            :disabled="!useCropCount"
+          />
+          <span>{{ t('randomTickTable.cropCount') }}</span>
+        </div>
+      </div>
+
+    </div>
+
+    <p class="rt-note mb-3">
+      {{ t('randomTickTable.note') }}
+    </p>
+
+    <!-- ── Table ── -->
+    <div class="rt-table-wrapper">
+      <table class="wikitable rt-table">
+        <thead>
+          <tr>
+            <th>{{ t('randomTickTable.col.block') }}</th>
+            <th>{{ t('randomTickTable.col.avgPerAction') }}</th>
+            <th>{{ t('randomTickTable.col.avgTotal') }}</th>
+            <th>{{ t('randomTickTable.col.medianTotal') }}</th>
+            <th>{{ t('randomTickTable.col.avgDrops') }}</th>
+            <th>{{ useCropCount
+              ? t('randomTickTable.col.avgTimeForItemsWithCrops', targetItems, { named: { n: targetItems, crops: cropCount } })
+              : t('randomTickTable.col.avgTimeForItems', targetItems, { named: { n: targetItems } })
+            }}</th>
+            <th>{{ t('randomTickTable.col.notes') }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in rows" :key="row.entry.name">
+
+            <!-- Name / link -->
+            <td v-html="row.renderedLink" />
+
+            <!-- Avg time per action -->
+            <td class="rt-time">
+              {{ fmtTime(row.avgPerAction) }}
+              <span class="rt-ticks">{{ fmtTicks(row.avgPerAction) }}</span>
+            </td>
+
+            <!-- Avg total growth -->
+            <td class="rt-time">
+              <template v-if="row.stagesIsNull">
+                ({{ fmtTime(row.avgTotal) }})
+                <span class="rt-ticks">({{ fmtTicks(row.avgTotal) }})</span>
+              </template>
+              <template v-else>
+                {{ fmtTime(row.avgTotal) }}
+                <span class="rt-ticks">{{ fmtTicks(row.avgTotal) }}</span>
+              </template>
+            </td>
+
+            <!-- Median total growth -->
+            <td class="rt-time">
+              <template v-if="row.medianTotal !== null">
+                <template v-if="row.medianExact">
+                  {{ fmtTime(row.medianTotal) }}
+                  <span class="rt-ticks">{{ fmtTicks(row.medianTotal) }}</span>
+                </template>
+                <template v-else>
+                  {{ t('randomTickTable.approx', { value: fmtTime(row.medianTotal) }) }}
+                  <span class="rt-ticks">{{ t('randomTickTable.approx', { value: fmtTicks(row.medianTotal) }) }}</span>
+                </template>
+              </template>
+              <template v-else>{{ t('randomTickTable.na') }}</template>
+            </td>
+
+            <!-- Avg drops -->
+            <td class="rt-center">
+              {{ row.avgDrops !== undefined
+                ? (row.avgDrops * (useCropCount ? cropCount : 1))
+                : t('randomTickTable.na') }}
+            </td>
+
+            <!-- Avg time for target items -->
+            <td class="rt-time">
+              <template v-if="row.avgTicksForTarget !== null">
+                {{ fmtTime(row.avgTicksForTarget) }}
+                <span class="rt-ticks">{{ fmtTicks(row.avgTicksForTarget) }}</span>
+              </template>
+              <template v-else>{{ t('randomTickTable.na') }}</template>
+            </td>
+
+            <!-- Notes -->
+            <td class="rt-notes">{{ row.entry.notes ?? '' }}</td>
+
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </CalcField>
+</template>
+
+<style lang="less">
+.rt-table-wrapper {
+  overflow-x: auto;
+}
+
+.rt-note {
+  font-size: 0.85rem;
+  color: var(--color-subtle, #666);
+  font-style: italic;
+}
+
+.rt-disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.rt-table {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: 0.9rem;
+
+  th, td {
+    padding: 5px 10px;
+    border: 1px solid var(--border-color-base, #a2a9b1);
+    vertical-align: middle;
+  }
+
+  th {
+    background: var(--background-color-neutral, #eaecf0);
+    font-weight: bold;
+    white-space: nowrap;
+  }
+
+  tr:nth-child(even) td {
+    background: var(--background-color-neutral-subtle, #f8f9fa);
+  }
+
+  .rt-center {
+    text-align: center;
+  }
+
+  .rt-time {
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .rt-ticks {
+    display: block;
+    font-size: 0.8em;
+    color: var(--color-subtle, #888);
+    font-family: monospace;
+  }
+
+  .rt-notes {
+    font-size: 0.85rem;
+    color: var(--color-subtle, #555);
+    min-width: 160px;
+  }
+}
+
+.input-input {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.cdx-text-input {
+  font-family: monospace;
+  width: 84px;
+}
+</style>

--- a/src/tools/randomTickTable/App.vue
+++ b/src/tools/randomTickTable/App.vue
@@ -276,11 +276,13 @@ const rows = computed((): RowData[] => {
 
             <!-- Notes -->
             <td class="rt-notes">{{ row.entry.notes ?? '' }}</td>
-
           </tr>
         </tbody>
       </table>
     </div>
+    <p class="rt-note mb-3">
+      {{ t('randomTickTable.edit') }}
+    </p>
   </CalcField>
 </template>
 

--- a/src/tools/randomTickTable/App.vue
+++ b/src/tools/randomTickTable/App.vue
@@ -10,12 +10,12 @@ const { t } = useI18n()
 // ── Types ──────────────────────────────────────────────────────────────────────
 
 interface Entry {
-  name: string            // Display name, also used as link target if link is absent
-  link?: string           // Optional wiki page name; falls back to name if omitted
-  stages?: number | null  // omit or null = single-action block (e.g. lit redstone ore)
-  growthChance?: number   // 0–1 probability of advancing one stage when ticked; defaults to 1.0
-  avgDrops?: number       // Average items dropped per harvest; omit for non-harvestable blocks
-  stackSize?: number      // Stack size for that item; defaults to 64
+  name: string | string[]  // Single name or list of names; all are linked
+  link?: string | string[] // Optional link target(s); if array must match length of name
+  stages?: number | null   // omit or null = single-action block (e.g. lit redstone ore)
+  growthChance?: number    // 0–1 probability of advancing one stage when ticked; defaults to 1.0
+  avgDrops?: number        // Average items dropped per harvest; omit for non-harvestable blocks
+  stackSize?: number       // Stack size for that item; defaults to 64
   notes?: string
 }
 
@@ -100,8 +100,20 @@ function fmtTicks(n: number): string {
 }
 
 function renderLink(entry: Entry): string {
-  const target = entry.link ?? entry.name
-  return parseWikitext(`[[${target}|${entry.name}]]`)
+  const names = Array.isArray(entry.name) ? entry.name : [entry.name]
+  const links = entry.link === undefined
+    ? names
+    : Array.isArray(entry.link) ? entry.link : [entry.link]
+
+  const linkedItems = names.map((name, i) => {
+    const target = links[i] ?? name
+    return parseWikitext(`[[${target}|${name}]]`)
+  })
+
+  if (linkedItems.length === 1) return linkedItems[0]
+  if (linkedItems.length === 2) return `${linkedItems[0]} ${t('randomTickTable.and')} ${linkedItems[1]}`
+  const allButLast = linkedItems.slice(0, -1).join(', ')
+  return `${allButLast}${t('randomTickTable.oxfordComma')} ${t('randomTickTable.and')} ${linkedItems[linkedItems.length - 1]}`
 }
 
 // ── Per-row computed data ──────────────────────────────────────────────────────
@@ -221,7 +233,7 @@ const rows = computed((): RowData[] => {
           </tr>
         </thead>
         <tbody>
-          <tr v-for="row in rows" :key="row.entry.name">
+          <tr v-for="(row, index) in rows" :key="index">
 
             <!-- Name / link -->
             <td v-html="row.renderedLink" />
@@ -277,13 +289,11 @@ const rows = computed((): RowData[] => {
 
             <!-- Notes -->
             <td class="rt-notes">{{ row.entry.notes ?? '' }}</td>
+
           </tr>
         </tbody>
       </table>
     </div>
-    <p class="rt-note mb-3">
-      {{ t('randomTickTable.edit') }}
-    </p>
   </CalcField>
 </template>
 

--- a/src/tools/randomTickTable/index.html
+++ b/src/tools/randomTickTable/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>randomTickTable</title>
+    <base target="_parent" />
+  </head>
+  <body>
+    <div id="app"></div>
+
+    <script type="module" src="/tools/randomTickTable/main.ts"></script>
+  </body>
+</html>

--- a/src/tools/randomTickTable/locale/en.json
+++ b/src/tools/randomTickTable/locale/en.json
@@ -1,0 +1,28 @@
+{
+  "randomTickTable.title": "Random Tick Reference Table",
+
+  "randomTickTable.rts": "randomTickSpeed",
+  "randomTickTable.rts.explain": "The /gamerule randomTickSpeed value (default: 3)",
+  "randomTickTable.targetItems": "Target items",
+  "randomTickTable.useCropCount": "Use crop count",
+  "randomTickTable.cropCount": "Crops growing",
+
+  "randomTickTable.note": "Median values marked ~ are numerical approximations — no closed-form exists for the negative binomial distribution. Exact medians are shown without ~ for single-stage mechanics. Growth times assume optimal conditions unless noted.",
+
+  "randomTickTable.approx": "~{value}",
+  "randomTickTable.na": "—",
+
+  "randomTickTable.unit.gt": "gt",
+  "randomTickTable.unit.s": "s",
+  "randomTickTable.unit.m": "m",
+  "randomTickTable.unit.h": "h",
+
+  "randomTickTable.col.block": "Block / mechanic",
+  "randomTickTable.col.avgPerAction": "Avg. time per action",
+  "randomTickTable.col.avgTotal": "Avg. total growth time",
+  "randomTickTable.col.medianTotal": "Median total growth time",
+  "randomTickTable.col.avgDrops": "Avg. drops / harvest",
+  "randomTickTable.col.avgTimeForItems": "Avg. time for {n} item | Avg. time for {n} items",
+  "randomTickTable.col.avgTimeForItemsWithCrops": "Avg. time for {n} item ({crops} crop) | Avg. time for {n} items ({crops} crops)",
+  "randomTickTable.col.notes": "Notes"
+}

--- a/src/tools/randomTickTable/locale/en.json
+++ b/src/tools/randomTickTable/locale/en.json
@@ -12,6 +12,8 @@
 
   "randomTickTable.approx": "~{value}",
   "randomTickTable.na": "—",
+  "randomTickTable.and": "and",
+  "randomTickTable.oxfordComma": ",",
 
   "randomTickTable.unit.gt": "gt",
   "randomTickTable.unit.s": "s",

--- a/src/tools/randomTickTable/locale/en.json
+++ b/src/tools/randomTickTable/locale/en.json
@@ -7,7 +7,8 @@
   "randomTickTable.useCropCount": "Use crop count",
   "randomTickTable.cropCount": "Crops growing",
 
-  "randomTickTable.note": "Median values marked ~ are numerical approximations — no closed-form exists for the negative binomial distribution. Exact medians are shown without ~ for single-stage mechanics. Growth times assume optimal conditions unless noted.",
+  "randomTickTable.note": "Median values marked ~ are numerical approximations — no closed-form exists for the negative binomial distribution. Exact medians are shown without ~ for single-stage mechanics.\nGrowth times assume optimal conditions unless noted.",
+  "randomTickTable.edit": "To edit this page, go to Template:RandomTickTable, where JSON data is stored.",
 
   "randomTickTable.approx": "~{value}",
   "randomTickTable.na": "—",
@@ -19,8 +20,8 @@
 
   "randomTickTable.col.block": "Block / mechanic",
   "randomTickTable.col.avgPerAction": "Avg. time per action",
-  "randomTickTable.col.avgTotal": "Avg. total growth time",
-  "randomTickTable.col.medianTotal": "Median total growth time",
+  "randomTickTable.col.avgTotal": "Avg. total growth",
+  "randomTickTable.col.medianTotal": "Median total growth",
   "randomTickTable.col.avgDrops": "Avg. drops / harvest",
   "randomTickTable.col.avgTimeForItems": "Avg. time for {n} item | Avg. time for {n} items",
   "randomTickTable.col.avgTimeForItemsWithCrops": "Avg. time for {n} item ({crops} crop) | Avg. time for {n} items ({crops} crops)",

--- a/src/tools/randomTickTable/main.ts
+++ b/src/tools/randomTickTable/main.ts
@@ -1,0 +1,21 @@
+import * as vue from 'vue'
+import { z } from 'zod'
+import { createMcwI18n } from '@/utils/i18n'
+import { getParams, handleParseError } from '@/utils/params'
+import plugin from '@/utils/plugin'
+import App from './App.vue'
+import '@/init'
+
+const targetEl = document.querySelector('#app')!
+const i18n = createMcwI18n([import.meta.glob('./locale/*.json', { eager: true })])
+
+;(async () => {
+  const parsed = z
+    .object({
+      entries: z.string().transform((val) => JSON.parse(val)),
+    })
+    .safeParse(await getParams())
+
+  const params = handleParseError(parsed, targetEl)
+  vue.createApp(App, params).use(i18n).use(plugin).mount(targetEl)
+})()


### PR DESCRIPTION
This adds two new calculators in the tools folder, randomTick and randomTickTable.
**RandomTick** calculates metrics on crops that use random tick, like average time for action, average and median growth time and also time for getting a stack of drops. You input the randomTickSpeed, number of growth stages it will go through (the max number that will be in the debug menu), average drops / harvest and stack size, and it generates a table of information.

**RandomTickTable** calculates a table of similar information for different crops / things that use random ticks. The list is not coded into the calculator, and is instead provided when you use the calculator. I'm planning on setting up Template:Random Tick Table with the correct info, then you can use that template, so that when you need to update for new crops you can do that on a single wiki-page. You can give it info on the random tick speed, count of items you want to gather, and optionally how many crops you have growing in parallel, which will be used to calculate the time it takes to get the number of items. 